### PR TITLE
Use vagrant-cachier plugin if installed

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -14,6 +14,11 @@ Vagrant.configure(2) do |config|
   # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "bento/centos-6.7"
 
+  # Use the vagrant-cachier plugin, if installed, to cache downloaded packages
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :box
+  end
+
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
   # `vagrant box outdated`. This is not recommended.


### PR DESCRIPTION
Cache downloaded packages to allow for faster redeployments if the
vagrant-cachier plugin is installed.