### PR TITLE
Updating GITHUB_URL to the publicly available repo

### DIFF
--- a/vagrant/oo-setup.sh
+++ b/vagrant/oo-setup.sh
@@ -5,7 +5,7 @@ cd /home/oneops
 
 export BUILD_BASE='/home/oneops/build'
 export OO_HOME='/home/oneops'
-export GITHUB_URL=git@oogit:oneops
+export GITHUB_URL='https://github.com/oneops'
 
 mkdir -p $BUILD_BASE
 
@@ -28,5 +28,3 @@ cp $BUILD_BASE/dev-tools/setup-scripts/* .
 
 now=$(date +"%T")
 echo "All done at : $now"
-
-


### PR DESCRIPTION
When trying to run the setup in vagrant, ran into an issue with access to the GitHub repo. This allows the provisioning script to finish executing.