### PR TITLE
Switching rvm gpg key fetch to use alt keyserver behind firewall

### DIFF
--- a/vagrant/install-rvm.sh
+++ b/vagrant/install-rvm.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 curl -sSL https://get.rvm.io | bash -s stable


### PR DESCRIPTION
I've modified the keyserver used to work behind corporate firewalls that block port 11371. Alternately `curl -sSL https://rvm.io/mpapis.asc | gpg --import -` could be used according to rvm documentation.