### PR TITLE
Adding .vagrant directory to .gitignore

### DIFF
--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/


### PR DESCRIPTION
Adding a .gitignore file with the directory .vagrant not tracked by git. This was custom vagrant files are not committed to the repository.