### PR TITLE
Note in prerequisites about Vagrant version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For a full-deployment of OneOps with metrics (back loop) use the core assembly w
 prerequisites
 =======
 
-install VirtualBox and Vagrant
+install VirtualBox and Vagrant (version 1.8 or above)
 
 (until public) add your public ssh key to your account at github.com
 


### PR DESCRIPTION
I tested this on Vagrant 1.4 (default version installed by apt on Ubuntu 14.04) and the box bento/centos-6.7 would not download automatically.  Installed Vagrant 1.8.1 from Hashicorp website and `vagrant up` worked as expected.  Noting version in Readme to avoid confusion.