### PR TITLE
update ruby 2.0.0 for centos6

### DIFF
--- a/vagrant/install-ruby.sh
+++ b/vagrant/install-ruby.sh
@@ -3,7 +3,7 @@
 export VAGRANT_MNT="/vagrant"
 
 source /usr/local/rvm/scripts/rvm
-rvm use --default --install 1.9.3
+rvm use --default --install 2.0.0
 shift
 gem install net-ssh -v 2.9.1
 gem install rails


### PR DESCRIPTION
Hi.

update ruby 2.0.0 for centos6.

Because oneops/display use "clipborad-rails".
but this gem needs ruby 2.0.0.

https://github.com/oneops/display/blob/master/Gemfile#L37
https://github.com/sadiqmmm/clipboard-rails/blob/master/clipboard-rails.gemspec#L22

For CentOS7, alreadry use ruby 2.0.0.
