### PR TITLE
Create networks

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,17 +1,38 @@
 # Prerequisites
 
+Docker 1.10.2 or or above
+Docker-compose 1.6.2 or above
+
+
+For Mac and Windows
 - install latest Docker Toolbox https://www.docker.com/products/docker-toolbox
 - create dedicated docker machine for oneops
 ~~~ bash
 docker-machine create -d virtualbox --virtualbox-memory "8196" oneops-docker-machine
 ~~~
+
+Note: After the virtual machine is created, you may want to shut it down and manually boost it's memory and CPU if you have more resources. This will increase performance. 
+
 - setup your shell and verify your docker machine
+
+On Mac
 ~~~ bash
 eval $(docker-machine env oneops-docker-machine)
 docker info
 ~~~
 
+On Windows
+~~~ bash
+FOR /f "tokens=*" %i IN ('docker-machine env oneops-docker-machine') DO %1
+docker info
+~~~
+
+
 To create a docker machine with a different driver see https://docs.docker.com/machine/drivers/
+
+For Linux
+Use your respective package manager (apt,yum etc.) To install the latest version of Docker.
+You can also install it manually as stated here https://docs.docker.com/linux/step_one/
 
 
 # Installation
@@ -27,9 +48,13 @@ export COMPOSE_PROJECT_NAME=oneops
 ~~~ bash
 docker-compose build
 ~~~
-- build oneops code ~ 15 min (re-run this command anytime you want to update your instance with latest oneops code)
+- build the standalone jenkins container
 ~~~ bash
-docker-compose run --rm jenkins build
+docker build -t oneops/jenkins jenkins
+~~~
+- build oneops code as stand alone external container ~ 15 min (re-run this command anytime you want to update your instance with latest oneops code)
+~~~ bash
+docker run -v oneops_home:/home/oneops oneops/jenkins
 ~~~
 - start oneops container images (oneops code is re-deployed on startup)
 ~~~ bash
@@ -44,14 +69,13 @@ activemq        /usr/bin/supervisord -n -c ...   Up      61616/tcp, 0.0.0.0:6161
 cassandra       /usr/bin/supervisord -n -c ...   Up      0.0.0.0:7000->7000/tcp, 0.0.0.0:9160->9160/tcp
 elasticsearch   /usr/bin/supervisord -n -c ...   Up      0.0.0.0:9200->9200/tcp, 0.0.0.0:9300->9300/tcp
 inductor        /usr/bin/supervisord -n -c ...   Up
-jenkins         /usr/bin/supervisord -n -c ...   Up      0.0.0.0:3001->3001/tcp
 logstash        /usr/bin/supervisord -n -c ...   Up      0.0.0.0:32768->5000/tcp
 postgres        /usr/bin/supervisord -n -c ...   Up      0.0.0.0:5432->5432/tcp
 rails           /usr/bin/supervisord -n -c ...   Up      0.0.0.0:3000->3000/tcp
 tomcat          /usr/bin/supervisord -n -c ...   Up      0.0.0.0:8080->8080/tcp
 ~~~
 
-To access your new oneops instance go to `http://<ip>:3000` where _ip_ is the ip address of your docker machine which you can retrieve with  `docker-machine ip oneops-docker-machine`
+To access your new oneops instance go to `http://<ip>:3000` where _ip_ is the ip address of your docker machine which you can retrieve with  `docker-machine ip oneops-docker-machine`. If you are on Linux then it is simply localhost. 
 
 
 # Troubleshooting

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - oneops_home:/home/oneops
       - opt:/opt/oneops
     networks:
-      - central
+      central:
       
 
   rails:
@@ -21,7 +21,7 @@ services:
       - oneops_home:/home/oneops
       - opt:/opt/oneops
     networks:
-      - central
+      central:
       
   tomcat:
     container_name: tomcat
@@ -31,7 +31,12 @@ services:
     volumes:
       - oneops_home:/home/oneops
     networks:
-      - central
+      central:
+        aliases:
+          - api
+          - cmsapi
+          - antenna
+          - sensor
       
   logstash:
     container_name: logstash
@@ -41,7 +46,7 @@ services:
     volumes:
       - oneops_home:/home/oneops
     networks:
-      - central
+      central:
 
   postgres:
     container_name: postgres
@@ -51,6 +56,12 @@ services:
     volumes:
       - oneops_home:/home/oneops
       - postgres:/var/lib/pgsql/9.2/data
+    networks:
+      central:
+        aliases:
+          - kloopzappdb
+          - kloopzcmsdb
+          - activitidb
 
   activemq:
     container_name: activemq
@@ -60,7 +71,13 @@ services:
     volumes:
       - oneops_home:/home/oneops
       - activemq:/kahadb
-
+    networks:
+      central:
+        aliases:
+          - kloopzmq
+          - searchmq
+          - opsmq
+          
   cassandra:
     container_name: cassandra
     build: cassandra
@@ -76,6 +93,12 @@ services:
       memlock:
         soft: -1
         hard: -1
+    networks:
+      central:
+        aliases:
+           - daq
+           - opsdb
+           - sysdb
 
   elasticsearch:
     container_name: elasticsearch

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,13 +6,11 @@ services:
     container_name: inductor
     build: inductor
     volumes:
-      - home:/home/oneops
+      - oneops_home:/home/oneops
       - opt:/opt/oneops
-    links:
-      - rails
-      - tomcat:api
-      - tomcat:cmsapi
-      - activemq
+    networks:
+      - central
+      
 
   rails:
     container_name: rails
@@ -20,42 +18,30 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - home:/home/oneops
+      - oneops_home:/home/oneops
       - opt:/opt/oneops
-    links:
-      - postgres:kloopzappdb
-      - tomcat:api
-      - tomcat:cmsapi
-      - tomcat:antenna
-      - tomcat:sensor
-
+    networks:
+      - central
+      
   tomcat:
     container_name: tomcat
     build: tomcat
     ports:
       - "8080:8080"
     volumes:
-      - home:/home/oneops
-    links:
-      - postgres:kloopzcmsdb
-      - postgres:activitidb
-      - activemq:amq
-      - activemq:kloopzmq
-      - activemq:searchmq
-      - activemq:opsmq
-      - cassandra:daq
-      - cassandra:opsdb
-      - cassandra:sysdb
-
+      - oneops_home:/home/oneops
+    networks:
+      - central
+      
   logstash:
     container_name: logstash
     build: logstash
     ports:
       - "5000"
     volumes:
-      - home:/home/oneops
-    links:
-      - elasticsearch
+      - oneops_home:/home/oneops
+    networks:
+      - central
 
   postgres:
     container_name: postgres
@@ -63,7 +49,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - home:/home/oneops
+      - oneops_home:/home/oneops
       - postgres:/var/lib/pgsql/9.2/data
 
   activemq:
@@ -72,7 +58,7 @@ services:
     ports:
       - "61617:61617"
     volumes:
-      - home:/home/oneops
+      - oneops_home:/home/oneops
       - activemq:/kahadb
 
   cassandra:
@@ -82,7 +68,7 @@ services:
       - "7000:7000"
       - "9160:9160"
     volumes:
-      - home:/home/oneops
+      - oneops_home:/home/oneops
       - cassandra:/opt/cassandra/data
     cap_add:
       - IPC_LOCK
@@ -98,22 +84,13 @@ services:
       - "9200:9200"
       - "9300:9300"
     volumes:
-      - home:/home/oneops
+      - oneops_home:/home/oneops
       - elasticsearch:/var/lib/elasticsearch
-
-  jenkins:
-    container_name: jenkins
-    build: jenkins
-    ports:
-     - "3001:3001"
-    volumes:
-     - home:/home/oneops
 
 volumes:
 
-  home:
-    external: false
-    driver: local
+  oneops_home:
+    external: true
 
   opt:
     external: false
@@ -134,3 +111,7 @@ volumes:
   elasticsearch:
     external: false
     driver: local
+
+networks:
+  central:
+    driver: bridge

--- a/docker/jenkins/Dockerfile
+++ b/docker/jenkins/Dockerfile
@@ -26,3 +26,4 @@ COPY build.sh build.sh
 RUN chmod +x build.sh
 RUN ln -s /home/oneops/build/build.sh /usr/bin/build
 RUN mkdir -p $OO_HOME/dist
+ENTRYPOINT ["/usr/bin/build"]


### PR DESCRIPTION
* Removed Jenkins from the compose so the container is not always running as a service.
* Added Jenkins build as a docker build instead of docker-compose build to build it as a external data container to be shared by all OneOps containers
* Created high level network instead of links. This will help with scaling when porting to Swarm.
* Fixed the Readme to reflect all the changes.

TODO: Need to fix the logstash container to run as non-root user for new docker version since it keeps crashing. 