### PR TITLE
Update oo-prereqs.sh

### DIFF
--- a/vagrant-centos7/oo-prereqs.sh
+++ b/vagrant-centos7/oo-prereqs.sh
@@ -22,7 +22,7 @@ systemctl start ntpd
 
 # postgres
 echo "OO install postgres 9.2"
-yum -y install http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/pgdg-centos92-9.2-6.noarch.rpm
+yum -y install http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/pgdg-centos92-9.2-8.noarch.rpm
 yum -y install postgresql92-server postgresql92-contrib
 yum -y install postgresql-devel
 


### PR DESCRIPTION
Yum repo no longer contains the patch 6 of the postgresql package but does contain the 9.2-8 version.  Updating to resolve setup issue #64 with the database not being available.