### PR TITLE
update postgresql version. pgdg-centos92-9.2-6.noarch.rpm returned 404

### DIFF
--- a/vagrant/oneops-jreqs.sh
+++ b/vagrant/oneops-jreqs.sh
@@ -19,7 +19,7 @@ service ntpd start
 
 # postgres
 echo "OO install postgres 9.2"
-yum -y install http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/pgdg-centos92-9.2-6.noarch.rpm
+yum -y install http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/pgdg-centos92-9.2-8.noarch.rpm
 yum -y install postgresql92-server postgresql92-contrib
 yum -y install postgresql-devel
 


### PR DESCRIPTION
vagrant up was throwing 404 error trying to download postgresql. Updated version number and it works locally now. If paths aren't static, consider a more dynamic approach rather than hardcoding.